### PR TITLE
Fix Discord invite links (placeholder → permanent)

### DIFF
--- a/Chapter01-AI-Coding-Intro/README.ko.md
+++ b/Chapter01-AI-Coding-Intro/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter01-AI-Coding-Intro/README.md
+++ b/Chapter01-AI-Coding-Intro/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter02-Installation/README.ko.md
+++ b/Chapter02-Installation/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter02-Installation/README.md
+++ b/Chapter02-Installation/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter03-First-Conversation/README.ko.md
+++ b/Chapter03-First-Conversation/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter03-First-Conversation/README.md
+++ b/Chapter03-First-Conversation/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter04-Working-with-Files/README.ko.md
+++ b/Chapter04-Working-with-Files/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter04-Working-with-Files/README.md
+++ b/Chapter04-Working-with-Files/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter05-Terminal-Commands/README.ko.md
+++ b/Chapter05-Terminal-Commands/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter05-Terminal-Commands/README.md
+++ b/Chapter05-Terminal-Commands/README.md
@@ -8,7 +8,7 @@
 
 If you have questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter06-Project-Structure/README.ko.md
+++ b/Chapter06-Project-Structure/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter06-Project-Structure/README.md
+++ b/Chapter06-Project-Structure/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter07-Context-and-Memory/README.ko.md
+++ b/Chapter07-Context-and-Memory/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter07-Context-and-Memory/README.md
+++ b/Chapter07-Context-and-Memory/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter08-Effective-Prompting/README.ko.md
+++ b/Chapter08-Effective-Prompting/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter08-Effective-Prompting/README.md
+++ b/Chapter08-Effective-Prompting/README.md
@@ -8,7 +8,7 @@
 
 If you have questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter09-Exploring-Code/README.ko.md
+++ b/Chapter09-Exploring-Code/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter09-Exploring-Code/README.md
+++ b/Chapter09-Exploring-Code/README.md
@@ -8,7 +8,7 @@
 
 If you have questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter10-Editing-Code/README.ko.md
+++ b/Chapter10-Editing-Code/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter10-Editing-Code/README.md
+++ b/Chapter10-Editing-Code/README.md
@@ -8,7 +8,7 @@
 
 If you have questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter11-Git-Basics/README.ko.md
+++ b/Chapter11-Git-Basics/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter11-Git-Basics/README.md
+++ b/Chapter11-Git-Basics/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter12-Project-Memory/README.ko.md
+++ b/Chapter12-Project-Memory/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter12-Project-Memory/README.md
+++ b/Chapter12-Project-Memory/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter13-Website-Development/README.ko.md
+++ b/Chapter13-Website-Development/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter13-Website-Development/README.md
+++ b/Chapter13-Website-Development/README.md
@@ -8,7 +8,7 @@
 
 If you have questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter14-Deployment/README.ko.md
+++ b/Chapter14-Deployment/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter14-Deployment/README.md
+++ b/Chapter14-Deployment/README.md
@@ -8,7 +8,7 @@
 
 If you have questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter15-Data-Storage/README.ko.md
+++ b/Chapter15-Data-Storage/README.ko.md
@@ -18,7 +18,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter15-Data-Storage/README.md
+++ b/Chapter15-Data-Storage/README.md
@@ -18,7 +18,7 @@
 
 If you have questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter16-Mini-Games/README.ko.md
+++ b/Chapter16-Mini-Games/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter16-Mini-Games/README.md
+++ b/Chapter16-Mini-Games/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions during your studies, feel free to ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter17-CLI-Tools/README.ko.md
+++ b/Chapter17-CLI-Tools/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter17-CLI-Tools/README.md
+++ b/Chapter17-CLI-Tools/README.md
@@ -8,7 +8,7 @@
 
 If you have questions while learning, ask in our Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask_Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter18-Chatbots/README.ko.md
+++ b/Chapter18-Chatbots/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter18-Chatbots/README.md
+++ b/Chapter18-Chatbots/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter19-Backend-Basics/README.ko.md
+++ b/Chapter19-Backend-Basics/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter19-Backend-Basics/README.md
+++ b/Chapter19-Backend-Basics/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter20-Full-Stack-Apps/README.ko.md
+++ b/Chapter20-Full-Stack-Apps/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter20-Full-Stack-Apps/README.md
+++ b/Chapter20-Full-Stack-Apps/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter21-Architecture/README.ko.md
+++ b/Chapter21-Architecture/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter21-Architecture/README.md
+++ b/Chapter21-Architecture/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter22-Advanced-Config/README.ko.md
+++ b/Chapter22-Advanced-Config/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter22-Advanced-Config/README.md
+++ b/Chapter22-Advanced-Config/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while studying, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter23-Hooks-and-Commands/README.ko.md
+++ b/Chapter23-Hooks-and-Commands/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter23-Hooks-and-Commands/README.md
+++ b/Chapter23-Hooks-and-Commands/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while studying, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter24-Agents-and-Skills/README.ko.md
+++ b/Chapter24-Agents-and-Skills/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter24-Agents-and-Skills/README.md
+++ b/Chapter24-Agents-and-Skills/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while studying, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter25-MCP-Integration/README.ko.md
+++ b/Chapter25-MCP-Integration/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter25-MCP-Integration/README.md
+++ b/Chapter25-MCP-Integration/README.md
@@ -8,7 +8,7 @@
 
 If you have any questions while studying, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter26-CI-CD-Automation/README.ko.md
+++ b/Chapter26-CI-CD-Automation/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter26-CI-CD-Automation/README.md
+++ b/Chapter26-CI-CD-Automation/README.md
@@ -8,7 +8,7 @@
 
 If you have questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 

--- a/Chapter27-Team-Collaboration/README.ko.md
+++ b/Chapter27-Team-Collaboration/README.ko.md
@@ -8,7 +8,7 @@
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-질문하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 
@@ -1692,7 +1692,7 @@ Part 3: 고급 (Chapter 22-27)
 
 ### 디스코드 커뮤니티
 
-[![Discord](https://img.shields.io/badge/Discord-바이브코딩_커뮤니티-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-바이브코딩_커뮤니티-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 **채널 소개**:
 - `#질문답변`: 학습 중 궁금한 점
@@ -1760,7 +1760,7 @@ Part 3: 고급 (Chapter 22-27)
 
 ---
 
-[![Discord](https://img.shields.io/badge/Discord-커뮤니티_참여-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-커뮤니티_참여-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 [![GitHub](https://img.shields.io/badge/GitHub-프로젝트_스타-181717?style=for-the-badge&logo=github&logoColor=white)](https://github.com/your-repo)
 
 ---

--- a/Chapter27-Team-Collaboration/README.md
+++ b/Chapter27-Team-Collaboration/README.md
@@ -8,7 +8,7 @@
 
 If you have questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Ask%20Questions-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 ---
 
@@ -1691,7 +1691,7 @@ Part 3: Advanced (Chapter 22-27)
 
 ### Discord Community
 
-[![Discord](https://img.shields.io/badge/Discord-Vibecoding_Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Vibecoding_Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 **Channel Introduction**:
 - `#questions`: Questions during learning
@@ -1759,7 +1759,7 @@ We support your development journey!
 
 ---
 
-[![Discord](https://img.shields.io/badge/Discord-Join_Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Join_Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 [![GitHub](https://img.shields.io/badge/GitHub-Star_Project-181717?style=for-the-badge&logo=github&logoColor=white)](https://github.com/your-repo)
 
 ---

--- a/Chapter28-Web3-Basics/README.ko.md
+++ b/Chapter28-Web3-Basics/README.ko.md
@@ -1,7 +1,7 @@
 # Chapter 28: Web3 기초
 
 ## 💬 질문하기
-[Discord](https://discord.gg/your-invite-link) - 막히면 여기서 질문하세요!
+[Discord](https://discord.gg/zpk3efB3aY) - 막히면 여기서 질문하세요!
 
 ## 🎯 이 챕터의 목표
 

--- a/Chapter28-Web3-Basics/README.md
+++ b/Chapter28-Web3-Basics/README.md
@@ -1,7 +1,7 @@
 # Chapter 28: Web3 Basics
 
 ## 💬 Ask Questions
-[Discord](https://discord.gg/your-invite-link) - When you're stuck, ask here!
+[Discord](https://discord.gg/zpk3efB3aY) - When you're stuck, ask here!
 
 ## 🎯 Goals for This Chapter
 

--- a/Chapter29-Farcaster-Frames/README.ko.md
+++ b/Chapter29-Farcaster-Frames/README.ko.md
@@ -1,7 +1,7 @@
 # Chapter 29: Farcaster Frames
 
 ## 💬 질문하기
-[Discord](https://discord.gg/your-invite-link) - 막히면 여기서 질문하세요!
+[Discord](https://discord.gg/zpk3efB3aY) - 막히면 여기서 질문하세요!
 
 ## 🎯 이 챕터의 목표
 

--- a/Chapter29-Farcaster-Frames/README.md
+++ b/Chapter29-Farcaster-Frames/README.md
@@ -1,7 +1,7 @@
 # Chapter 29: Farcaster Frames
 
 ## 💬 Ask Questions
-[Discord](https://discord.gg/your-invite-link) - When you're stuck, ask here!
+[Discord](https://discord.gg/zpk3efB3aY) - When you're stuck, ask here!
 
 ## 🎯 Goals for This Chapter
 

--- a/Chapter30-Base-Smart-Contracts/README.ko.md
+++ b/Chapter30-Base-Smart-Contracts/README.ko.md
@@ -1,7 +1,7 @@
 # Chapter 30: Base 스마트 컨트랙트
 
 ## 💬 질문하기
-[Discord](https://discord.gg/your-invite-link) - 막히면 여기서 질문하세요!
+[Discord](https://discord.gg/zpk3efB3aY) - 막히면 여기서 질문하세요!
 
 ## 🎯 이 챕터의 목표
 

--- a/Chapter30-Base-Smart-Contracts/README.md
+++ b/Chapter30-Base-Smart-Contracts/README.md
@@ -1,7 +1,7 @@
 # Chapter 30: Base Smart Contracts
 
 ## 💬 Ask Questions
-[Discord](https://discord.gg/your-invite-link) - When you're stuck, ask here!
+[Discord](https://discord.gg/zpk3efB3aY) - When you're stuck, ask here!
 
 ## 🎯 Goals for This Chapter
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -52,7 +52,7 @@ Claude Code를 기반으로 커리큘럼을 구성한 이유:
 - **Git 워크플로우** → 표준
 
 > 💡 **향후 계획**: Cursor, Windsurf, Jules 등 다른 도구 커리큘럼도 확장 예정입니다.
-> 관심 있으시면 [Discord](https://discord.gg/your-invite-link)에서 의견 주세요!
+> 관심 있으시면 [Discord](https://discord.gg/zpk3efB3aY)에서 의견 주세요!
 
 ---
 
@@ -81,7 +81,7 @@ Claude Code를 기반으로 커리큘럼을 구성한 이유:
 
 학습 중 궁금한 점이 있으면 디스코드에서 질문하세요!
 
-[![Discord](https://img.shields.io/badge/Discord-커뮤니티_참여하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-커뮤니티_참여하기-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 - 질문과 답변
 - 프로젝트 공유
@@ -455,7 +455,7 @@ Ch.28: 소비자 🛒      Ch.29: 빌더 🔨       Ch.30: 창조자 ⚡
 
 1. **Claude에게 질문**: "이게 뭐야?", "왜 이 에러가 나?"
 2. **용어 사전 확인**: [GLOSSARY.ko.md](./GLOSSARY.ko.md)
-3. **커뮤니티에 질문**: [Discord](https://discord.gg/your-invite-link)
+3. **커뮤니티에 질문**: [Discord](https://discord.gg/zpk3efB3aY)
 4. **이전 챕터 복습**: 답이 거기 있는 경우가 많음
 
 ### 초보자가 자주 하는 실수

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This curriculum goes beyond the official Claude Code tutorial to provide:
 
 If you have questions while learning, ask on Discord!
 
-[![Discord](https://img.shields.io/badge/Discord-Join_Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/your-invite-link)
+[![Discord](https://img.shields.io/badge/Discord-Join_Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/zpk3efB3aY)
 
 - Questions and Answers
 - Project Sharing
@@ -440,7 +440,7 @@ Claim tokens/NFTs      Viral distribution    NFT-gated communities
 
 1. **Ask Claude**: "What is this?", "Why does this error happen?"
 2. **Check the Glossary**: [GLOSSARY.md](./GLOSSARY.md)
-3. **Ask the Community**: [Discord](https://discord.gg/your-invite-link)
+3. **Ask the Community**: [Discord](https://discord.gg/zpk3efB3aY)
 4. **Review previous chapter**: Often the answer is there
 
 ### Common Beginner Mistakes


### PR DESCRIPTION
## Summary
- Replaced all placeholder Discord invite links across curriculum markdown files
- `discord.gg/your-invite-link` → `discord.gg/zpk3efB3aY` (permanent VibeDojo invite)

## Scope
- **69 replacements** across **62 files**
- URL-only changes, no content modifications
- Fixes onboarding friction for new users clicking broken Discord links

## Test Plan
- [x] Verified no `your-invite-link` patterns remain
- [x] Verified all chapters have correct `zpk3efB3aY` link

🤖 Generated with [Claude Code](https://claude.ai/code)